### PR TITLE
Update README to have SVG-based badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # lita-confirmation
 
-[![Build Status](https://travis-ci.org/jimmycuadra/lita-confirmation.png?branch=master)](https://travis-ci.org/jimmycuadra/lita-confirmation)
-[![Code Climate](https://codeclimate.com/github/jimmycuadra/lita-confirmation.png)](https://codeclimate.com/github/jimmycuadra/lita-confirmation)
-[![Coverage Status](https://coveralls.io/repos/jimmycuadra/lita-confirmation/badge.png)](https://coveralls.io/r/jimmycuadra/lita-confirmation)
+[![RubyGems](https://img.shields.io/gem/v/lita-confirmation.svg)](https://rubygems.org/gems/lita-confirmation)
+[![Build Status](https://img.shields.io/travis/jimmycuadra/lita-confirmation/master.svg)](https://travis-ci.org/jimmycuadra/lita-confirmation)
+[![Code Climate](https://img.shields.io/codeclimate/github/jimmycuadra/lita-confirmation.svg)](https://codeclimate.com/github/jimmycuadra/lita-confirmation)
+[![Coverage Status](https://img.shields.io/coveralls/jimmycuadra/lita-confirmation/master.svg)](https://coveralls.io/r/jimmycuadra/lita-confirmation)
 
 **lita-confirmation** is an extension for [Lita](https://www.lita.io/) that allows handler routes to require "confirmation" before being triggered. Confirmation consists of a second message sent to the robot with a confirmation code.
 


### PR DESCRIPTION
Quick update while I'm in here for other things, this switches README.md
to use [shields.io](http://shields.io/) for SVG badges, and adds a RubyGems version badge.

Any interest in a license badge?
