### PR TITLE
Allow confirm to reference the alias if it exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: ruby
 rvm:
-  - 2.0.0
-script: bundle exec rake
-before_install:
-  - gem update --system
+  - 2.1
+  - 2.2
 services:
   - redis-server
+sudo: false
+cache: bundler
 notifications:
   webhooks:
     urls:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This will result in the following behavior:
 
 ```
 Alice: Lita, danger
-Lita: This command requires confirmation. To confirm, send the command "confirm 636f308"
+Lita: This command requires confirmation. To confirm, send the command: Lita confirm 636f308
 Alice: Lita, confirm 636f308
 Lita: Dangerous command executed!
 ```
@@ -47,7 +47,7 @@ route /danger/, :danger, command: true, confirmation: { allow_self: false }
 
 ```
 Alice: Lita, danger
-Lita: This command requires confirmation. To confirm, send the command "confirm 636f308"
+Lita: This command requires confirmation. To confirm, send the command: Lita confirm 636f308
 Alice: Lita, confirm 636f308
 Lita: Confirmation 636f308 must come from a different user.
 Bob: Lita, confirm 636f308
@@ -64,7 +64,7 @@ route /danger/, :danger, command: true, confirmation: { restrict_to: :managers }
 
 ```
 Alice: Lita, danger
-Lita: This command requires confirmation. To confirm, send the command "confirm 636f308"
+Lita: This command requires confirmation. To confirm, send the command: Lita confirm 636f308
 Alice: Lita, confirm 636f308
 Lita: Confirmation 636f308 must come from a user in one of the following authorization groups: managers
 Manager: Lita, confirm 636f308
@@ -81,7 +81,7 @@ route /danger/, :danger, command: true, confirmation: { expire_after: 10 }
 
 ```
 Alice: Lita, danger
-Lita: This command requires confirmation. To confirm, send the command "confirm 636f308"
+Lita: This command requires confirmation. To confirm, send the command: Lita confirm 636f308
 Alice: Waiting 15 seconds...
 Alice: Lita, confirm 636f308
 Lita: 636f308 is not a valid confirmation code. It may have expired. Please run the original command again.

--- a/lib/lita/extensions/confirmation.rb
+++ b/lib/lita/extensions/confirmation.rb
@@ -24,6 +24,7 @@ module Lita
           message.reply(
             I18n.t(
               "lita.extensions.confirmation.request",
+              prefix: @robot.alias ? @robot.alias : "#{@robot.mention_name} ",
               code: UnconfirmedCommand.new(handler, message, robot, route, options).code
             )
           )

--- a/lib/lita/extensions/confirmation.rb
+++ b/lib/lita/extensions/confirmation.rb
@@ -24,7 +24,7 @@ module Lita
           message.reply(
             I18n.t(
               "lita.extensions.confirmation.request",
-              prefix: @robot.alias ? @robot.alias : "#{@robot.mention_name} ",
+              prefix: @robot.alias ? @robot.alias : "#{@robot.mention_format(@robot.mention_name)} ",
               code: UnconfirmedCommand.new(handler, message, robot, route, options).code
             )
           )

--- a/lita-confirmation.gemspec
+++ b/lita-confirmation.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", ">= 4.0"
+  spec.add_runtime_dependency "lita", ">= 4.6.1"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,7 +2,7 @@ en:
   lita:
     extensions:
       confirmation:
-        request: This command requires confirmation. To confirm, send the command "confirm %{code}"
+        request: "This command requires confirmation. To confirm, send the command: %{prefix}confirm %{code}"
     handlers:
       confirmation:
         help:

--- a/spec/lita/extensions/confirmation_spec.rb
+++ b/spec/lita/extensions/confirmation_spec.rb
@@ -38,7 +38,7 @@ describe Dangerous, lita_handler: true do
   context "with confirmation: true" do
     it "requires confirmation" do
       send_command("danger")
-      expect(replies.last).to match(/send the command: Lita confirm [a-f0-9]{6}/)
+      expect(replies.last).to match(/send the command: Lita: confirm [a-f0-9]{6}/)
     end
 
     it "requires confirmation with an alias if one is set" do

--- a/spec/lita/extensions/confirmation_spec.rb
+++ b/spec/lita/extensions/confirmation_spec.rb
@@ -38,19 +38,25 @@ describe Dangerous, lita_handler: true do
   context "with confirmation: true" do
     it "requires confirmation" do
       send_command("danger")
-      expect(replies.last).to match(/send the command "confirm [a-f0-9]{6}"/)
+      expect(replies.last).to match(/send the command: Lita confirm [a-f0-9]{6}/)
+    end
+
+    it "requires confirmation with an alias if one is set" do
+      robot.alias = "!"
+      send_command("danger")
+      expect(replies.last).to match(/send the command: !confirm [a-f0-9]{6}/)
     end
 
     it "invokes the original route on confirmation" do
       send_command("danger")
-      code = replies.last.match(/([a-f0-9]{6})"$/)[1]
+      code = replies.last.match(/\s([a-f0-9]{6})$/)[1]
       send_command("confirm #{code}")
       expect(replies.last).to eq("Dangerous command executed!")
     end
 
     it "expires when confirmed" do
       send_command("danger")
-      code = replies.last.match(/([a-f0-9]{6})"$/)[1]
+      code = replies.last.match(/\s([a-f0-9]{6})$/)[1]
       send_command("confirm #{code}")
       send_command("confirm #{code}")
       expect(replies.last).to include("not a valid confirmation code")
@@ -66,14 +72,14 @@ describe Dangerous, lita_handler: true do
   context "with allow_self: false" do
     it "responds with a message if the user tries to confirm their own command" do
       send_command("danger self")
-      code = replies.last.match(/([a-f0-9]{6})"$/)[1]
+      code = replies.last.match(/\s([a-f0-9]{6})$/)[1]
       send_command("confirm #{code}")
       expect(replies.last).to include("must come from a different user")
     end
 
     it "invokes the original route on confirmation by another user" do
       send_command("danger self")
-      code = replies.last.match(/([a-f0-9]{6})"$/)[1]
+      code = replies.last.match(/\s([a-f0-9]{6})$/)[1]
       send_command("confirm #{code}", as: Lita::User.create(123))
       expect(replies.last).to eq("Dangerous command confirmed by another user and executed!")
     end
@@ -88,7 +94,7 @@ describe Dangerous, lita_handler: true do
 
     it "responds with a message if a user not in a required group tries to confirm a command" do
       send_command("danger restrict")
-      code = replies.last.match(/([a-f0-9]{6})"$/)[1]
+      code = replies.last.match(/\s([a-f0-9]{6})$/)[1]
       send_command("confirm #{code}")
       expect(replies.last).to include(
         "must come from a user in one of the following authorization groups: managers"
@@ -97,7 +103,7 @@ describe Dangerous, lita_handler: true do
 
     it "invokes the original route on confirmation by a manager" do
       send_command("danger restrict")
-      code = replies.last.match(/([a-f0-9]{6})"$/)[1]
+      code = replies.last.match(/\s([a-f0-9]{6})$/)[1]
       send_command("confirm #{code}", as: manager)
       expect(replies.last).to include("confirmed by a manager")
     end
@@ -108,7 +114,7 @@ describe Dangerous, lita_handler: true do
 
     it "invokes the original route on confirmation within the expiry" do
       send_command("danger expire")
-      code = replies.last.match(/([a-f0-9]{6})"$/)[1]
+      code = replies.last.match(/\s([a-f0-9]{6})$/)[1]
       send_command("confirm #{code}")
       expect(replies.last).to include("within 0 seconds")
     end
@@ -116,7 +122,7 @@ describe Dangerous, lita_handler: true do
     it "responds that the code is invalid after 0 seconds" do
       allow(Thread).to receive(:new).and_yield
       send_command("danger expire")
-      code = replies.last.match(/([a-f0-9]{6})"$/)[1]
+      code = replies.last.match(/\s([a-f0-9]{6})$/)[1]
       send_command("confirm #{code}")
       expect(replies.last).to include("not a valid confirmation code")
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "simplecov"
 require "coveralls"
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]


### PR DESCRIPTION
One of my plugins makes use of lita-confirmation pretty heavily, and I've noticed users making a lot of "copypasta" errors, where they copy the confirm but forget to make it a command.  This change:
1. Makes it so if an alias is set on the robot, that will be shown in
   the confirmation message.
2. Adjusts the confirmation message to not have quotes (another source
   of copypasta frustration).
3. Adds and adjusts tests as appropriate.
