### PR TITLE
Trigger :message_dispatched when confirmed command is dispatched

### DIFF
--- a/lib/lita/extensions/confirmation/unconfirmed_command.rb
+++ b/lib/lita/extensions/confirmation/unconfirmed_command.rb
@@ -39,6 +39,13 @@ module Lita
 
           expire
           timer_thread.kill if timer_thread
+          robot.trigger(
+            :message_dispatched,
+            handler: handler,
+            route: route,
+            message: message,
+            robot: robot
+          )
           handler.dispatch_to_route(route, robot, message)
         end
 

--- a/spec/lita/extensions/confirmation_spec.rb
+++ b/spec/lita/extensions/confirmation_spec.rb
@@ -54,6 +54,17 @@ describe Dangerous, lita_handler: true do
       expect(replies.last).to eq("Dangerous command executed!")
     end
 
+    it "triggers the appropriate routes on confirmation" do
+      expect(robot).to receive(:trigger).with(
+        :unhandled_message, hash_including(:message))
+      expect(robot).to receive(:trigger).with(
+        :message_dispatched, hash_including(:handler, :route, :message, :robot)
+      ).twice
+      send_command("danger")
+      code = replies.last.match(/\s([a-f0-9]{6})$/)[1]
+      send_command("confirm #{code}")
+    end
+
     it "expires when confirmed" do
       send_command("danger")
       code = replies.last.match(/\s([a-f0-9]{6})$/)[1]


### PR DESCRIPTION
I'm using lita-confirmation in conjunction with lita-metrics, and I
discovered that commands requiring confirmation were not being logged
properly as valid commands. With this change, the :message_dispatched
event is triggered explicitly so that both the command requiring
confirmation and the confirmation itself are logged.
